### PR TITLE
fixed numpad for non-arabic digits

### DIFF
--- a/lib/widgets/numpad.dart
+++ b/lib/widgets/numpad.dart
@@ -54,8 +54,8 @@ class NumPad extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     void onTypeNumber(int number) {
-      String num = "";
-      if (arabicDigits == true) num = number.toString().toArabicNumbers;
+      String num = arabicDigits == true ? number.toString().toArabicNumbers : number.toString();
+
       onType(returnItAsEnglish == true ? num.toEnglishNumbers : num);
     }
 


### PR DESCRIPTION
onTypeNumber(int number) method was not working when arabicDigits value was set to false, added new else statement.